### PR TITLE
fix: catch ejson errors

### DIFF
--- a/run-decrypt.sh
+++ b/run-decrypt.sh
@@ -2,16 +2,24 @@
 
 # Get the list of modified and added files
 FILES=$(git diff --cached --name-status | awk '$1 == "M" || $1 == "A" { print $2 }')
+EXIT_CODE=0
 
-# Loop through the files and decrypt if they match the ejson extension
+# Loop through the files and encrypt if they match the ejson extension
 for FILE in $FILES; do
   if [ "${FILE##*.}" = "ejson" ]; then
     # Encrypt the ejson file
-    ejson decrypt $FILE
-    # Stage the decrypted file
-    git add $FILE
+    ejson_output=$(ejson decrypt $FILE 2>&1)
+
+    # check if ejson exit code is different from 0
+    if [ $? -ne 0 ]; then
+        echo "Error encoding file $FILE: $ejson_output"
+        EXIT_CODE=1
+    else
+      # Stage the decrypted file
+      git add $FILE
+    fi
   fi
 done
 
 # Continue with the commit
-exit 0
+exit $EXIT_CODE

--- a/run-encrypt.sh
+++ b/run-encrypt.sh
@@ -2,16 +2,24 @@
 
 # Get the list of modified and added files
 FILES=$(git diff --cached --name-status | awk '$1 == "M" || $1 == "A" { print $2 }')
+EXIT_CODE=0
 
 # Loop through the files and encrypt if they match the ejson extension
 for FILE in $FILES; do
   if [ "${FILE##*.}" = "ejson" ]; then
     # Encrypt the ejson file
-    ejson encrypt $FILE
-    # Stage the decrypted file
-    git add $FILE
+    ejson_output=$(ejson encrypt $FILE 2>&1)
+
+    # check if ejson exit code is different from 0
+    if [ $? -ne 0 ]; then
+        echo "Error encoding file $FILE: $ejson_output"
+        EXIT_CODE=1
+    else
+      # Stage the decrypted file
+      git add $FILE
+    fi
   fi
 done
 
 # Continue with the commit
-exit 0
+exit $EXIT_CODE


### PR DESCRIPTION
# Description

Fixing not catch execution errors from ejson command

## Task Context

### What is the current behavior?

If the ejson command exit with errors and codes different from 0, hokks will not report it and finish successfully

### What is the new behavior?

Execution validates if there are errors on ejson execution, print a messaje for the involved files and return the hook with appropiate exit code to fail.

### Additional Context

<!-- Add here any additional context you think is important. -->
